### PR TITLE
Fixes webgateway compilation errors.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,9 @@ lagomUnmanagedServices in ThisBuild += ("ldap" -> "http://127.0.0.1:9200")
 
 // Common settings for all subprojects
 def commonSettings: Seq[Setting[_]] = Seq(
-  evictionWarningOptions in update := EvictionWarningOptions.default.withWarnTransitiveEvictions(false)
+  evictionWarningOptions in update := EvictionWarningOptions.default.withWarnTransitiveEvictions(false),
+  resolvers +=
+    "Shibboleth" at "https://build.shibboleth.net/nexus/content/repositories/releases"
 )
 
 //======================================================================================================================
@@ -72,9 +74,8 @@ lazy val `web-gateway` = (project in file("web-gateway"))
   .dependsOn(`user-api`)
   .settings(
     libraryDependencies ++= Seq(
-      lagomScaladslServer,
+//      lagomScaladslServer,
       ehcache,
-      cacheApi,
       guice,
       Dependencies.macwire,
       Dependencies.scalaTest

--- a/web-gateway/app/WebGatewayLoader.scala
+++ b/web-gateway/app/WebGatewayLoader.scala
@@ -1,34 +1,35 @@
 import com.example.lps.api.UserService
-import com.lightbend.lagom.scaladsl.api.{LagomConfigComponent, ServiceAcl, ServiceInfo}
+import com.lightbend.lagom.scaladsl.api.{ LagomConfigComponent, ServiceAcl, ServiceInfo }
 import com.lightbend.lagom.scaladsl.client.LagomServiceClientComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
-import com.lightbend.lagom.scaladsl.server.{LagomApplication, LagomApplicationContext}
 import com.lightbend.rp.servicediscovery.lagom.scaladsl.LagomServiceLocatorComponents
 import com.softwaremill.macwire._
-import controllers.MainController
-import org.pac4j.play.scala.{DefaultSecurityComponents, SecurityComponents}
+import controllers.{ AssetsComponents, MainController }
+import org.pac4j.core.config.Config
+import org.pac4j.play.scala.DefaultSecurityComponents
 import org.pac4j.play.store.PlayCacheSessionStore
 import org.webjars.play.WebJarsUtil
-import play.api.inject.guice.{GuiceApplicationBuilder, GuiceApplicationLoader}
-import controllers.AssetsComponents
-import modules.SecurityModule
 import play.api.ApplicationLoader.Context
-import play.api.Mode.Prod
-import play.api.inject.Injector
+import play.api.cache.DefaultSyncCacheApi
+import play.api.cache.ehcache.EhCacheComponents
 import play.api.libs.ws.ahc.AhcWSComponents
-import play.api.{ApplicationLoader, BuiltInComponentsFromContext, Configuration, Mode}
-import play.controllers.AssetsComponents
+import play.api.mvc.BodyParsers
+import play.api.{ ApplicationLoader, BuiltInComponentsFromContext, Mode }
+import play.cache.SyncCacheApiAdapter
 import play.filters.HttpFiltersComponents
-import play.filters.components.HttpFiltersComponents
-import play.libs.ws.ahc.AhcWSComponents
 import router.Routes
 
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 
 abstract class WebGateway(context: Context) extends BuiltInComponentsFromContext(context)
+  with AssetsComponents
+  with HttpFiltersComponents
+  with AhcWSComponents
   with LagomConfigComponent
-  with LagomServiceClientComponents {
+  with LagomServiceClientComponents
+  with EhCacheComponents
+{
 
   override lazy val serviceInfo: ServiceInfo = ServiceInfo(
     "web-gateway",
@@ -38,19 +39,29 @@ abstract class WebGateway(context: Context) extends BuiltInComponentsFromContext
   )
   override implicit lazy val executionContext: ExecutionContext = actorSystem.dispatcher
 
+
+  lazy val errHandler  = httpErrorHandler
   override lazy val router = {
     val prefix = "/"
     wire[Routes]
   }
 
-  import  play.api.inject.{bind => guiceBind}
-  private val injector: Injector = GuiceApplicationBuilder(
-    environment = environment,
-    configuration = configuration)
-        .bindings(new SecurityModule(environment, configuration))
-        .bindings(guiceBind[SecurityComponents].to[DefaultSecurityComponents])
-    .build().injector
-  injector.instanceOf(classOf[SecurityComponents]) // use the injector to extract instances of the desired types from Guice
+  //  private val injector: Injector = GuiceApplicationBuilder(
+  //    environment = environment,
+  //    configuration = configuration)
+  //        .bindings(new SecurityModule(environment, configuration))
+  //        .bindings(guiceBind[SecurityComponents].to[DefaultSecurityComponents])
+  //    .build().injector
+  //  injector.instanceOf(classOf[SecurityComponents]) // use the injector to extract instances of the desired types from Guice
+
+  lazy val pacSyncCache:play.api.cache.SyncCacheApi = new DefaultSyncCacheApi(defaultCacheApi)
+  lazy val pcSyncCache:play.cache.SyncCacheApi = wire[SyncCacheApiAdapter]
+  lazy val sessionStore: org.pac4j.play.store.PlaySessionStore = wire[PlayCacheSessionStore]
+
+  lazy val pac4jConfig: org.pac4j.core.config.Config = new Config()
+  lazy val secComponents: org.pac4j.play.scala.SecurityComponents = wire[DefaultSecurityComponents]
+
+  lazy val bodyParsersDefault = wire[BodyParsers.Default]
 
   lazy implicit val webjars = wire[WebJarsUtil]
 
@@ -58,9 +69,7 @@ abstract class WebGateway(context: Context) extends BuiltInComponentsFromContext
 
   lazy val userService = serviceClient.implement[UserService]
 
-
 }
-
 
 class WebGatewayLoader extends ApplicationLoader {
   override def load(context: Context) = context.environment.mode match {


### PR DESCRIPTION
Not sure about a couple of things though:

 * `lazy val errHandler  = httpErrorHandler` is required to prevent an ambiguity in `wire[Routes]`. This is Play turf and I'm not familiar with it.
 * `lazy val pac4jConfig: org.pac4j.core.config.Config = new Config()` is pac4j and it's exactly where you'll want to plugin clients and other facny pac4j thhingies.
 * the caches and session store is a bit of a dance so that pac4j has a session store and because it required a java implementation of the play cache I did the caches dance using the `SyncCacheApiAdapter`. Again, this is Play stuff I?m not familiar with.